### PR TITLE
feat: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig – https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.ts]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Add an `.editorconfig` file to ensure consistent whitespace and formatting across all editors and IDEs.

Closes #39

## Changes

- **2-space indentation** for TypeScript (`.ts`) and JSON (`.json`) files
- **LF line endings** across all files
- **UTF-8 charset** as the default
- **Trim trailing whitespace** (disabled for Markdown files to preserve intentional line breaks)
- **Insert final newline** on all files
- **Tab indentation** for Makefiles (standard convention)

## Testing

This is a configuration-only change — no build, test, or typecheck impact. Verified the file follows the [EditorConfig spec](https://editorconfig.org) and matches the project's existing conventions (2-space indent TypeScript, etc.).