### PR TITLE
ci: path-scoped CI triggers per package

### DIFF
--- a/.github/workflows/ci-file-converter.yml
+++ b/.github/workflows/ci-file-converter.yml
@@ -1,21 +1,17 @@
-name: CI — Root
+name: CI — file-converter
 
 on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/file-converter/**'
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/file-converter/**'
 
 jobs:
-  all-packages:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +29,10 @@ jobs:
         run: npm install
 
       - name: Type check
-        run: npm run typecheck
+        run: npm run typecheck -w packages/file-converter
 
       - name: Build
-        run: npm run build
+        run: npm run build -w packages/file-converter
 
       - name: Test
-        run: npm test
+        run: npm run test -w packages/file-converter

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -1,21 +1,17 @@
-name: CI — Root
+name: CI — retry
 
 on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/retry/**'
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/retry/**'
 
 jobs:
-  all-packages:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +29,10 @@ jobs:
         run: npm install
 
       - name: Type check
-        run: npm run typecheck
+        run: npm run typecheck -w packages/retry
 
       - name: Build
-        run: npm run build
+        run: npm run build -w packages/retry
 
       - name: Test
-        run: npm test
+        run: npm run test -w packages/retry

--- a/.github/workflows/ci-sandbox.yml
+++ b/.github/workflows/ci-sandbox.yml
@@ -1,21 +1,17 @@
-name: CI — Root
+name: CI — sandbox
 
 on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/sandbox/**'
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/sandbox/**'
 
 jobs:
-  all-packages:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +29,10 @@ jobs:
         run: npm install
 
       - name: Type check
-        run: npm run typecheck
+        run: npm run typecheck -w packages/sandbox
 
       - name: Build
-        run: npm run build
+        run: npm run build -w packages/sandbox
 
       - name: Test
-        run: npm test
+        run: npm run test -w packages/sandbox

--- a/.github/workflows/ci-token-counter.yml
+++ b/.github/workflows/ci-token-counter.yml
@@ -1,21 +1,17 @@
-name: CI — Root
+name: CI — token-counter
 
 on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/token-counter/**'
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/token-counter/**'
 
 jobs:
-  all-packages:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +29,10 @@ jobs:
         run: npm install
 
       - name: Type check
-        run: npm run typecheck
+        run: npm run typecheck -w packages/token-counter
 
       - name: Build
-        run: npm run build
+        run: npm run build -w packages/token-counter
 
       - name: Test
-        run: npm test
+        run: npm run test -w packages/token-counter

--- a/.github/workflows/ci-web-scraper.yml
+++ b/.github/workflows/ci-web-scraper.yml
@@ -1,21 +1,17 @@
-name: CI — Root
+name: CI — web-scraper
 
 on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/web-scraper/**'
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'tsconfig.json'
-      - '.github/**'
+      - 'packages/web-scraper/**'
 
 jobs:
-  all-packages:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +29,10 @@ jobs:
         run: npm install
 
       - name: Type check
-        run: npm run typecheck
+        run: npm run typecheck -w packages/web-scraper
 
       - name: Build
-        run: npm run build
+        run: npm run build -w packages/web-scraper
 
       - name: Test
-        run: npm test
+        run: npm run test -w packages/web-scraper


### PR DESCRIPTION
## Summary
- Each of the 5 packages (`retry`, `token-counter`, `web-scraper`, `sandbox`, `file-converter`) now has its own CI workflow
- Workflows only trigger when files in that specific package change (`paths: packages/<name>/**`)
- Root CI workflow now only runs when shared config (package.json, tsconfig, .github/) changes
- A PR touching only `retry` will only run `retry`'s tests — not all 5 packages

## Why
Monorepo CI should not run all tests on every PR. Path-scoped triggers keep CI fast and focused as packages grow.

## Test plan
- [ ] Open a PR touching only `packages/retry/` — verify only `ci-retry` workflow runs
- [ ] Open a PR touching root `package.json` — verify only `ci` (root) workflow runs
- [ ] Open a PR touching multiple packages — verify only those packages' workflows run