### PR TITLE
Add CI workflow template to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Each package lives in `packages/<name>/` and is independently publishable.
 - Include a README with install + usage examples
 - Include tests
 - Use TypeScript strict mode
+- Include a CI workflow (see [Adding a CI Workflow](#adding-a-ci-workflow) below)
 
 ## Package Structure
 
@@ -45,6 +46,55 @@ Every package.json should scope to `@agent-tools/`:
 }
 ```
 
+## Adding a CI Workflow
+
+Every new package **must** include its own CI workflow. This keeps CI fast — a PR touching only your package runs only your package's tests, not the entire repo.
+
+Create `.github/workflows/ci-<your-package>.yml`:
+
+```yaml
+name: CI — <your-package>
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/<your-package>/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/<your-package>/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type check
+        run: npm run typecheck -w packages/<your-package>
+
+      - name: Build
+        run: npm run build -w packages/<your-package>
+
+      - name: Test
+        run: npm run test -w packages/<your-package>
+```
+
+Replace `<your-package>` with your package directory name (e.g., `retry`, `sandbox`). Your `package.json` must include `typecheck`, `build`, and `test` scripts for this to work.
+
 ## PR Guidelines
 
 1. One package or feature per PR
@@ -52,6 +102,7 @@ Every package.json should scope to `@agent-tools/`:
 3. Include tests that pass
 4. Keep dependencies minimal — prefer Node.js built-ins
 5. Write clear, copy-pasteable usage examples in the README
+6. New packages must include a path-scoped CI workflow (see template above)
 
 ## What We Don't Want
 


### PR DESCRIPTION
## Summary
- Adds a **CI workflow requirement** for new packages in `CONTRIBUTING.md`
- Includes a ready-to-copy YAML template with path-scoped triggers so contributors know exactly what to include
- Adds CI workflow to the PR guidelines checklist

This way every new package ships with its own CI — no single PR runs the full test suite unnecessarily.

## Related
- Replaces the approach from #50 (per-package CI workflows) by making it a contributor responsibility instead of a bot-maintained set of files