### PR TITLE
[codex] Fix single-quoted href parsing in web-scraper

### DIFF
--- a/packages/web-scraper/src/__tests__/scraper.test.ts
+++ b/packages/web-scraper/src/__tests__/scraper.test.ts
@@ -126,6 +126,19 @@ describe("extractLinks", () => {
     strictEqual(links[1].url, "https://test.dev/path");
     strictEqual(links[1].text, "Read more");
   });
+
+  it("continues to support unquoted href values", () => {
+    const html = `
+      <a href=/docs class='link'>Docs</a>
+      <a class="cta" href=https://example.com/pricing data-role='primary'>Pricing</a>
+    `;
+    const links = extractLinks(html, "https://agent.tools/base/");
+    strictEqual(links.length, 2);
+    strictEqual(links[0].url, "https://agent.tools/docs");
+    strictEqual(links[0].text, "Docs");
+    strictEqual(links[1].url, "https://example.com/pricing");
+    strictEqual(links[1].text, "Pricing");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web-scraper/src/__tests__/scraper.test.ts
+++ b/packages/web-scraper/src/__tests__/scraper.test.ts
@@ -100,6 +100,32 @@ describe("extractLinks", () => {
     const links = extractLinks(html);
     strictEqual(links[0].text, "Bold link");
   });
+
+  it("handles single-quoted href values with mixed quoting styles", () => {
+    const html = `
+      <a href='https://example.com/docs' class="link" data-track='hero'>Docs</a>
+      <a class='nav-item' href='/pricing' aria-label="Pricing page">Pricing</a>
+    `;
+    const links = extractLinks(html, "https://agent.tools/base/");
+    strictEqual(links.length, 2);
+    strictEqual(links[0].url, "https://example.com/docs");
+    strictEqual(links[0].text, "Docs");
+    strictEqual(links[1].url, "https://agent.tools/pricing");
+    strictEqual(links[1].text, "Pricing");
+  });
+
+  it("keeps parsing when later quoted attributes contain >", () => {
+    const html = `
+      <a href='https://example.com/docs' data-title='A > B' class='link'>Example</a>
+      <a class="cta" href='https://test.dev/path' data-note="1 > 0"><strong>Read</strong> more</a>
+    `;
+    const links = extractLinks(html);
+    strictEqual(links.length, 2);
+    strictEqual(links[0].url, "https://example.com/docs");
+    strictEqual(links[0].text, "Example");
+    strictEqual(links[1].url, "https://test.dev/path");
+    strictEqual(links[1].text, "Read more");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web-scraper/src/scraper.ts
+++ b/packages/web-scraper/src/scraper.ts
@@ -186,13 +186,21 @@ export function extractText(html: string): string {
  * Extract all `<a>` links with their text and resolved URLs.
  */
 export function extractLinks(html: string, baseUrl?: string): Link[] {
-  const linkRegex = /<a\s[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+?)[\s>])[^>]*>([\s\S]*?)<\/a>/gi;
+  const anchorRegex = /<a\b((?:"[^"]*"|'[^']*'|[^'">])*)>([\s\S]*?)<\/a>/gi;
+  const hrefRegex = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i;
   const links: Link[] = [];
 
   let match: RegExpExecArray | null;
-  while ((match = linkRegex.exec(html)) !== null) {
-    const rawUrl = match[1] ?? match[2] ?? match[3] ?? "";
-    const rawText = match[4] ?? "";
+  while ((match = anchorRegex.exec(html)) !== null) {
+    const attrs = match[1] ?? "";
+    const rawText = match[2] ?? "";
+    const hrefMatch = hrefRegex.exec(attrs);
+
+    if (!hrefMatch) {
+      continue;
+    }
+
+    const rawUrl = hrefMatch[1] ?? hrefMatch[2] ?? hrefMatch[3] ?? "";
 
     // Strip inner tags from link text
     const text = decodeEntities(rawText.replace(/<[^>]+>/g, " "))


### PR DESCRIPTION
## Summary

Fixes `extractLinks()` so anchor parsing stays quote-aware after `href`, which prevents later quoted attributes containing `>` from breaking single-quoted `href` extraction.

Fixes #37

## What changed

- replaced the single all-in-one anchor regex with a two-step parse
- matched the full `<a ...>` opening tag without treating `>` inside quotes as tag-ending
- extracted `href` from the attribute string with a dedicated regex
- added regression tests for mixed quoting styles and `>` inside later quoted attributes

## Validation

- `npm test --workspace @agent-tools/web-scraper`
- `npm run typecheck --workspace @agent-tools/web-scraper`