### PR TITLE
fix: skip broad 'bug' keyword match for new-tool proposals

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -156,7 +156,8 @@ jobs:
             const text = title + ' ' + body;
             const labels = [];
 
-            if (title.includes('[bug]') || text.includes('bug')) labels.push('bug');
+            const isNewTool = title.includes('[new tool]');
+            if (title.includes('[bug]') || (!isNewTool && text.includes('bug'))) labels.push('bug');
             if (title.includes('[feature]') || text.includes('feature request')) labels.push('enhancement');
             if (title.includes('[new tool]')) {
               labels.push('new-tool');


### PR DESCRIPTION
> **Immutable PR Policy:** This PR will be reviewed exactly once, as-is. Any additional commits pushed after opening will automatically close it. Make sure everything is ready before you submit. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#immutable-pr-policy).

## Summary

Fixes false-positive `bug` label being applied to `[new tool]` proposals when the word "bug" appears incidentally in their body text (e.g. "debug", "diagnose failures").

## Related Issue

Closes #128

## Changes

- Added `isNewTool` guard to skip the broad `text.includes('bug')` check when the issue title starts with `[new tool]`
- Explicit `[bug]` title prefix still works as before

## Testing

- [x] All existing tests pass (`npm test`)
- [x] New tests added for new functionality — N/A (workflow logic, not testable in unit tests)
- [x] Type-check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Tested manually — verified logic handles the 4 previously mislabeled issues (#100, #111, #124, #127)

## Checklist

- [x] Code follows project style guidelines
- [x] No unnecessary dependencies added
- [x] Package README updated (if applicable) — N/A
- [x] Root README table updated (if new package) — N/A
- [x] **I understand this PR is final — no additional commits after opening**